### PR TITLE
 カメラ画面で、シャッター画面用の初期値をセット

### DIFF
--- a/camera/Camera/CameraViewController.swift
+++ b/camera/Camera/CameraViewController.swift
@@ -152,11 +152,7 @@ class CameraViewController: SuperViewController, AVCaptureVideoDataOutputSampleB
         
         setUpBackCamera()
     }
-    
-    override func viewWillAppear(_ animated: Bool) {
-        self.soundName = userDefaults.string(forKey: "シャッター音")!
-    }
-    
+
     @objc internal func onDownShutterButton(sender: UIButton) {
         UIView.animate(withDuration: 0.06,
                        animations: { () -> Void in

--- a/camera/Common/SuperViewController.swift
+++ b/camera/Common/SuperViewController.swift
@@ -14,6 +14,7 @@ class SuperViewController: UIViewController, AVAudioPlayerDelegate {
     let userDefaults = UserDefaults.standard
     var audioPlayer : AVAudioPlayer!
     var soundName: String = ""
+    var shutterImageName: String = ""
 
     let headerView: UIView = {
         let view = UIView()
@@ -25,7 +26,13 @@ class SuperViewController: UIViewController, AVAudioPlayerDelegate {
         super.viewDidLoad()
         self.view.backgroundColor = UIColor.black
         
-        setDefault(key: "デフォルト", value: "シャッター音")
+        self.setDefault(key: "シャッター音", value: "デフォルト")
+        self.setDefault(key: "シャッター画面", value: "黒画面")
+    }
+    
+    override func viewWillAppear(_ animated: Bool) {
+        self.soundName = userDefaults.string(forKey: "シャッター音")!
+        self.shutterImageName = userDefaults.string(forKey: "シャッター画面")!
     }
     
     /*
@@ -66,8 +73,8 @@ class SuperViewController: UIViewController, AVAudioPlayerDelegate {
      */
     // デフォルト値のセット
     func setDefault(key: String, value: String){
-        if ((userDefaults.string(forKey: key)) == nil) {
-            userDefaults.set(value, forKey: key)
+        if ((self.userDefaults.string(forKey: key)) == nil) {
+            self.userDefaults.set(value, forKey: key)
         }
     }
 


### PR DESCRIPTION
### WHAT
 カメラ画面でシャッター画面用の初期値をセット

### WHY
初期値のセットをしないとエラーを吐くため

#37 